### PR TITLE
Atualização estilo documentação

### DIFF
--- a/01-essential-information.md
+++ b/01-essential-information.md
@@ -12,8 +12,8 @@ Para a instalação bem-sucedida do framework são necessários os seguintes sof
 + [Apache](https://httpd.apache.org/download.cgi)
 + [Composer](https://getcomposer.org/download/)
 
-O *mod_rewrite* deve estar habilitado. Caso contrário o MVC não terá efeito e o *Apache* irá reportar o erro **"Not Found"**.
+O *mod_rewrite* deve estar habilitado. Caso contrário o MVC não terá efeito e o *Apache* irá reportar o erro <b>"Not Found"</b>.
 
 ----
 
-**Para lhe auxiliar neste processo, confira essa série completa de videoaulas gratuitas sobre os requisitos para programar PHP na sua máquina: [Série completa do canal HXTUTORS](https://goo.gl/9oQNr5)**
+<b>Para lhe auxiliar neste processo, confira essa série completa de videoaulas gratuitas sobre os requisitos para programar PHP na sua máquina: [Série completa do canal HXTUTORS](https://goo.gl/9oQNr5)</b>

--- a/02-installation-and-configuration.md
+++ b/02-installation-and-configuration.md
@@ -61,7 +61,7 @@ Para alterá-la: `$configs->env->nomedoambiente->baseURI = '/hxphp/';`.
 
 Os módulos padrão de ambiente são: `Database` e `Mail`. Os módulos não são padronizados.
 
-Para criar um módulo é necessário salvá-lo na pasta: `/src/HXPHP/System/Configs/Modules/` e **adicioná-lo na lista de módulos** do arquivo `/src/HXPHP/System/Configs/RegisterModules.php`.
+Para criar um módulo é necessário salvá-lo na pasta: `/src/HXPHP/System/Configs/Modules/` e <b>adicioná-lo na lista de módulos</b> do arquivo `/src/HXPHP/System/Configs/RegisterModules.php`.
 
 
 Exemplo demonstrando o registro de um módulo qualquer chamado Youtube (RegisterModules.php):
@@ -194,4 +194,4 @@ Após constatar que o [Composer](https://getcomposer.org/download) está em plen
 
 ----
 
-**Para lhe auxiliar neste processo, confira essa série completa de videoaulas gratuitas sobre instalação e uso do Composer: [Série completa do canal HXTUTORS](https://goo.gl/9oQNr5)**
+<b>Para lhe auxiliar neste processo, confira essa série completa de videoaulas gratuitas sobre instalação e uso do Composer: [Série completa do canal HXTUTORS](https://goo.gl/9oQNr5)</b>

--- a/03-kickoff.md
+++ b/03-kickoff.md
@@ -71,8 +71,8 @@ Com as situações ilustradas acima é possível compreender claramente o proces
 
 Mas, isso não é tudo! Essa requisição é subdividida em:
   
-+ `controller` -> <b>projetos<b>
-+ `action` -> <b>listar<b>
++ `controller` -> <b>projetos</b>
++ `action` -> <b>listar</b>
 + `parâmetro(s)` -> <b>1</b>
 
 #### Subpastas

--- a/03-kickoff.md
+++ b/03-kickoff.md
@@ -64,8 +64,8 @@ Mas afinal de contas para que serve essa configuração? Pois bem, ela é a fron
 
 Na prática, imagine os seguintes links requisitados por um usuário qualquer em ambos os exemplos:
   
-+ http://site.com.br`/`**projetos/listar/1**
-+ http://localhost`/hxphp/`**projetos/listar/1**
++ <a>http://site.com.br<code>/</code><strong>projetos/listar/1</strong></a>
++ <a>http://localhost<code>/hxphp/</code><strong>projetos/listar/1</strong></a>
   
 Com as situações ilustradas acima é possível compreender claramente o processo de separação, visto que, em ambas as situações a requisição foi: `projetos/listar/1`.
 

--- a/03-kickoff.md
+++ b/03-kickoff.md
@@ -71,26 +71,26 @@ Com as situações ilustradas acima é possível compreender claramente o proces
 
 Mas, isso não é tudo! Essa requisição é subdividida em:
   
-+ `controller` -> *projetos*
-+ `action` -> *listar*
-+ `parâmetro(s)` -> *1*
++ `controller` -> <b>projetos<b>
++ `action` -> <b>listar<b>
++ `parâmetro(s)` -> <b>1</b>
 
 #### Subpastas
 
 Também é possível organizar os *controllers* em subpastas. Esta funcionalidade permite uma fácil integração entre back e front-end, por exemplo. Confira o exemplo:
-  
-+ http://localhost`/hxphp/`**admin/projetos/novo/**
-+ http://localhost`/hxphp/`**projetos/listar/1**
-  
+
++ <a>http://localhost<code>/hxphp/</code><b>admin/projetos/listar/1</b></a>
++ <a>http://localhost<code>/hxphp/</code><b>/projetos/listar/1</b></a>
+
 Essa requisição é subdividida em:
 
 ```
   http://localhost/hxphp/admin/projetos/novo/
 ```
   
-+ `subpasta` -> *admin*
-+ `controller` -> *projetos*
-+ `action` -> *novo*
++ `subpasta` -> <b>admin</b>
++ `controller` -> <b>projetos</b>
++ `action` -> <b>novo</b>
 + `parâmetro(s)` -> null
 
 ```
@@ -98,12 +98,12 @@ Essa requisição é subdividida em:
 ```
   
 + `subpasta` -> null
-+ `controller` -> *projetos*
-+ `action` -> *listar*
-+ `parâmetro(s)` -> *1*
++ `controller` -> <b>projetos</b>
++ `action` -> <b>listar</b>
++ `parâmetro(s)` -> <b>1</b>
 
 
-**Para utilizar esta funcionalidade é necessária a existência da respectiva subpasta no diretório dos controllers. Se a subpasta não existir, o valor é automaticamente interpretado como Controller.**
+<b>Para utilizar esta funcionalidade é necessária a existência da respectiva subpasta no diretório dos controllers. Se a subpasta não existir, o valor é automaticamente interpretado como Controller.</b>
 
 Veja abaixo a estrutura necessária para reproduzir o exemplo acima:
 
@@ -121,7 +121,7 @@ Veja abaixo a estrutura necessária para reproduzir o exemplo acima:
         listar.phtml
 ```
 
-**Obs: A configuração de subpasta também se aplica às views!**
+<b>Obs: A configuração de subpasta também se aplica às views!</b>
 
 O *Controller* e a *Action* tem posição fixa, mas os parâmetros são infinitos, ou seja, desde que você especifique os dois primeiros valores da requisição, poderá passar quantos parâmetros desejar!
 

--- a/03-kickoff.md
+++ b/03-kickoff.md
@@ -64,8 +64,8 @@ Mas afinal de contas para que serve essa configuração? Pois bem, ela é a fron
 
 Na prática, imagine os seguintes links requisitados por um usuário qualquer em ambos os exemplos:
   
-+ <a>http://site.com.br<code>/</code><strong>projetos/listar/1</strong></a>
-+ <a>http://localhost<code>/hxphp/</code><strong>projetos/listar/1</strong></a>
++ <a>http://site.com.br<code>/</code><b>projetos/listar/1</b></a>
++ <a>http://localhost<code>/hxphp/</code><b>projetos/listar/1</b></a>
   
 Com as situações ilustradas acima é possível compreender claramente o processo de separação, visto que, em ambas as situações a requisição foi: `projetos/listar/1`.
 

--- a/04-controllers.md
+++ b/04-controllers.md
@@ -19,7 +19,7 @@ Resumindo, nesta camada é decidido o “se”, “o que”, “quando” e “o
 
 Agora que você já sabe o que é um *controller* e a sua importância para o funcionamento da aplicação, você poderá finalmente criar o seu primeiro *controller*. Para tal, siga estes passos:
 
-+ Defina o link desejado (Ex: http://site.com.br/`produtos`/ ou http://site.com.br/`lista-de-produtos`/);
++ Defina o link desejado (Ex: http://site.com.br/<code>produtos</code>/ ou http://site.com.br/<code>lista-de-produtos</code>/);
 + Crie um arquivo nomeado no padrão *CamelCase*; com o link desejado, sem espaços, hífens ou *underscores*; com o sufixo 'Controller', e; a extensão '.php'. Ou seja, para os exemplos acima, os controllers seriam: `ProdutosController.php` e `ListaDeProdutosController.php`;
 + Salve este arquivo na pasta: `app/controllers/`
 
@@ -38,7 +38,7 @@ Após salvar o arquivo, comece com o desenvolvimento de seu código e atente-se 
 Fique atento às seguintes características do código listado acima:
 
 + O nome da classe é igual ao nome do arquivo;
-+ Cada *controller* é uma extensão da classe mestre `*\HXPHP\System\Controller*`, e;
++ Cada *controller* é uma extensão da classe mestre `<em>\HXPHP\System\Controller</em>`, e;
 + A `indexAction()`, *action* padrão do controller, é executada automaticamente.
 
 Mas, afinal de contas o que são *actions*?
@@ -49,7 +49,7 @@ Mas, afinal de contas o que são *actions*?
 
 Após criar o *controller* é provável que seja necessário a criação de *actions* específicas e, para tal, siga estes passos:
 
-+ Defina o link desejado, por exemplo: http://site.com.br/produtos/`listar`/ , e;
++ Defina o link desejado, por exemplo: http://site.com.br/produtos/<code>listar</code>/ , e;
 + No *controller* desejado, crie um método `público` nomeado com o link desejado, sem espaços, hífens ou *underscores*; com o sufixo 'Action'.
 
 O código resultante do exemplo acima seria:
@@ -97,7 +97,7 @@ Algumas observações importantes:
 + Estes argumentos podem ser nomeados livremente, porém devem ter <b>obrigatoriamente um valor pré-definido</b>, por exemplo: `listarAction($categoria = '', $pagina = 1)`, e;
 + Os argumentos devem ser declarados na mesma ordem que os parâmetros.
 
-Através deste mecanismo é possível ter `<b>N</b> parâmetros` e nomeá-los de forma sugestiva, o que possibilitará uma melhor experiência com seus códigos.
+Através deste mecanismo é possível ter <code><b>N</b> parâmetros</code> e nomeá-los de forma sugestiva, o que possibilitará uma melhor experiência com seus códigos.
 
 ----
 
@@ -148,7 +148,7 @@ Caso queira utilizar os valores das configurações e até mesmo recursos como o
 É muito comum que seja necessário o processo de redirecionamento nos *controllers*.
 
 Imagine o seguinte processo:
-`produtos/cadastrar/ <b>-></b> produtos/salvar/ <b>-></b> produtos/listar/`
+<code>produtos/cadastrar/ <b>-></b> produtos/salvar/ <b>-></b> produtos/listar/</code>
 
 Após o formulário ser processado e disparado para a *action* <code><b>salvar</b></code> será necessário um redirecionamento para a *action* <code><b>listar</b></code> e para fazermos isto utilizamos o seguinte código:
 

--- a/04-controllers.md
+++ b/04-controllers.md
@@ -38,7 +38,7 @@ Após salvar o arquivo, comece com o desenvolvimento de seu código e atente-se 
 Fique atento às seguintes características do código listado acima:
 
 + O nome da classe é igual ao nome do arquivo;
-+ Cada *controller* é uma extensão da classe mestre `<em>\HXPHP\System\Controller</em>`, e;
++ Cada *controller* é uma extensão da classe mestre `<i>\HXPHP\System\Controller</i>`, e;
 + A `indexAction()`, *action* padrão do controller, é executada automaticamente.
 
 Mas, afinal de contas o que são *actions*?

--- a/04-controllers.md
+++ b/04-controllers.md
@@ -38,7 +38,7 @@ Após salvar o arquivo, comece com o desenvolvimento de seu código e atente-se 
 Fique atento às seguintes características do código listado acima:
 
 + O nome da classe é igual ao nome do arquivo;
-+ Cada *controller* é uma extensão da classe mestre `<i>\HXPHP\System\Controller</i>`, e;
++ Cada *controller* é uma extensão da classe mestre <code><em>\HXPHP\System\Controller</em></code>, e;
 + A `indexAction()`, *action* padrão do controller, é executada automaticamente.
 
 Mas, afinal de contas o que são *actions*?

--- a/04-controllers.md
+++ b/04-controllers.md
@@ -1,16 +1,16 @@
 ----
 
 ## Controllers {#controllers}
-Esta seção aborda a primeira das três camadas do padrão **MVC**.
+Esta seção aborda a primeira das três camadas do padrão <b>MVC</b>.
 
 ----
 ### O que são Controllers? {#o-que-sao-controllers}
 
-No padrão **MVC** existem basicamente três camadas: *Model*, *View* e *Controller*. 
+No padrão <b>MVC</b> existem basicamente três camadas: *Model*, *View* e *Controller*.
 
 O *controller* é o intermediário entre as outras duas camadas, ou seja, ele controla (daí o nome) todo o fluxo de informação do site/sistema.
 
-Em outras palavras, o *controller*, comumente chamado de **controlador**, tem como objetivo definir as propriedades da visualização (*view*), isto é, ele tem a função de condicionar, executar as regras de negócio(*models*), interpretar parâmetros, dentre muitas outras.
+Em outras palavras, o *controller*, comumente chamado de <b>controlador</b>, tem como objetivo definir as propriedades da visualização (*view*), isto é, ele tem a função de condicionar, executar as regras de negócio(*models*), interpretar parâmetros, dentre muitas outras.
 
 Resumindo, nesta camada é decidido o “se”, “o que”, “quando” e “onde” deve funcionar na nossa aplicação.
 
@@ -72,7 +72,7 @@ O erro 404, comumente chamado de *Error Not Found*, é um dos erros mais conheci
 
 Como já mencionado na seção de [funcionamento da URL](#funcionamento-da-url), os parâmetros que serão interpretados no controlador (*controller*) devem constar na URL, ou seja, é necessário que o *controller* e a *action* sejam definidos.
 
-Com estas condições atendidas tem-se a seguinte estrutura: 
+Com estas condições atendidas tem-se a seguinte estrutura:
 ```
   http://site.com.br/controller/action/parametro1/parametro2/parametro3/
 ```
@@ -94,10 +94,10 @@ O código resultante do exemplo acima seria:
 Algumas observações importantes:
 
 + Os parâmetros devem ser declarados como argumentos do método (*action*);
-+ Estes argumentos podem ser nomeados livremente, porém devem ter **obrigatoriamente um valor pré-definido**, por exemplo: `listarAction($categoria = '', $pagina = 1)`, e;
++ Estes argumentos podem ser nomeados livremente, porém devem ter <b>obrigatoriamente um valor pré-definido</b>, por exemplo: `listarAction($categoria = '', $pagina = 1)`, e;
 + Os argumentos devem ser declarados na mesma ordem que os parâmetros.
 
-Através deste mecanismo é possível ter `**N** parâmetros` e nomeá-los de forma sugestiva, o que possibilitará uma melhor experiência com seus códigos.
+Através deste mecanismo é possível ter `<b>N</b> parâmetros` e nomeá-los de forma sugestiva, o que possibilitará uma melhor experiência com seus códigos.
 
 ----
 
@@ -115,7 +115,7 @@ Portanto, quando criar métodos construtores siga este padrão:
 ```php
   class ProdutosController extends \HXPHP\System\Controller
   {
-    
+
     public function __construct()
     {
       parent::__construct();
@@ -130,7 +130,7 @@ Caso queira utilizar os valores das configurações e até mesmo recursos como o
 ```php
   class ProdutosController extends \HXPHP\System\Controller
   {
-    
+
     public function __construct($configs)
     {
       parent::__construct($configs);
@@ -148,9 +148,9 @@ Caso queira utilizar os valores das configurações e até mesmo recursos como o
 É muito comum que seja necessário o processo de redirecionamento nos *controllers*.
 
 Imagine o seguinte processo:
-`produtos/cadastrar/ **->** produtos/salvar/ **->** produtos/listar/`
+`produtos/cadastrar/ <b>-></b> produtos/salvar/ <b>-></b> produtos/listar/`
 
-Após o formulário ser processado e disparado para a *action* `**salvar**` será necessário um redirecionamento para a *action* `**listar**` e para fazermos isto utilizamos o seguinte código:
+Após o formulário ser processado e disparado para a *action* <code><b>salvar</b></code> será necessário um redirecionamento para a *action* <code><b>listar</b></code> e para fazermos isto utilizamos o seguinte código:
 
 
 ```php

--- a/05-models.md
+++ b/05-models.md
@@ -1,11 +1,11 @@
 ----
 ## *Models* {#models}
-Nesta seção você irá conhecer mais uma das três camadas do padrão **MVC**.
+Nesta seção você irá conhecer mais uma das três camadas do padrão <b>MVC</b>.
 
 ----
 
 ### O que são *Models*? {#o-que-sao-models}
-Os *models*, comumente chamados de **modelos**, são responsáveis por todos os processos relacionados à dados. Ou seja, o processo de leitura, escrita e validação de dados é realizado nesta camada. Estas rotinas são chamadas de **regras de negócio**.
+Os *models*, comumente chamados de <b>modelos</b>, são responsáveis por todos os processos relacionados à dados. Ou seja, o processo de leitura, escrita e validação de dados é realizado nesta camada. Estas rotinas são chamadas de <b>regras de negócio</b>.
 
 O modelo acessa qualquer tipo de informação, isto é, desde um banco de dados até um arquivo *XML*.
 As informações obtidas no modelo são repassadas para o controlador que, mediante a necessidade, repassa para a visualização. Em outro caminho existe o envio de informações da visualização para o controlador; que, por sua vez, envia para o modelo, e; este consuma o processo realizando as devidas alterações nos dados.
@@ -19,10 +19,10 @@ Para aproveitar dos benefícios do *ORM* é necessário que o *model* herde as c
 
 O código base de um *model* é:
 ```php
-	class NomeDoModel extends \HXPHP\System\Model
-	{
-		...
-	}
+class NomeDoModel extends \HXPHP\System\Model
+{
+        ...
+}
 ```
 
 As convenções da nomenclatura dos *models* são ditas pelo *ORM* vigente, portanto estas serão abordadas em uma seção específica.
@@ -49,7 +49,7 @@ De toda forma, é recomendado que você leia a documentação oficial para compr
 A questão fundamental no uso deste *ORM* está nas convenções de nomenclatura das tabelas do banco de dados e dos *models*. Confira a lista das 5 principais:
 
 + Todas as tabelas devem ser nomeadas em INGLÊS;
-+ O nome do model é o **singular** do nome da tabela;
++ O nome do model é o <b>singular</b> do nome da tabela;
 + O nome do model deverá ser escrito no padrão CamelCase;
 + A chave primária deve ser 'id' e NÃO 'ID' ou 'Id', e;
 + {Tabela} login_attempts => {Model} LoginAttempt / lost_passwords => LostPassword.
@@ -59,13 +59,13 @@ A questão fundamental no uso deste *ORM* está nas convenções de nomenclatura
 ### *Model* na prática {#model-na-pratica}
 
 ```php
-	class Product extends \HXPHP\System\Model
-	{
-		static function exists($product_code)
-		{
-			$product = self::find_by_code($product_code);
+class Product extends \HXPHP\System\Model
+{
+    static function exists($product_code)
+    {
+        $product = self::find_by_code($product_code);
 
-			return !is_null($product) ? true : false;
-		}
-	}
+        return !is_null($product) ? true : false;
+    }
+}
 ```

--- a/06-views.md
+++ b/06-views.md
@@ -80,7 +80,6 @@ class ProdutosController extends \HXPHP\System\Controller
 ```php
 class ProdutosController extends \HXPHP\System\Controller
 {
-
     public function indexAction()
     {
       $this->view->setVar('mensagem', 'Hello World')

--- a/06-views.md
+++ b/06-views.md
@@ -1,12 +1,12 @@
 ----
 ## *Views* {#views}
 
-Nesta seção você irá conhecer a última das três camadas do padrão **MVC**.
+Nesta seção você irá conhecer a última das três camadas do padrão <b>MVC</b>.
 
 ----
 ### O que são *views*? {#o-que-sao-views}
 
-As *views*, comumente chamadas de **interfaces**, são responsáveis por toda parte gráfica de nossa aplicação. É a camada que acomoda nossos códigos HTML.
+As *views*, comumente chamadas de <b>interfaces</b>, são responsáveis por toda parte gráfica de nossa aplicação. É a camada que acomoda nossos códigos HTML.
 
 ----
 ### Criando *views* {#criando-views}
@@ -20,21 +20,21 @@ As *views* são organizadas da seguinte forma: <br>
 
 #### Subpastas
 
-Quando o parâmetro `subfolder` existe, isto é, atende aos requisitos mencionados na seção de Funcionamento da URL, as *views* também deverão ser organizadas nas respectivas subpastas do diretório `app/views`. 
+Quando o parâmetro `subfolder` existe, isto é, atende aos requisitos mencionados na seção de Funcionamento da URL, as *views* também deverão ser organizadas nas respectivas subpastas do diretório `app/views`.
 
 Um exemplo para o link (`http://www.site.com.br/hxphp/admin/produtos/listar`):
 
 ```
 app/
-	views/
-		admin/
-			produtos/
-				listar.phtml
+    views/
+        admin/
+            produtos/
+                    listar.phtml
 ```
 
 #### Convenções
 
-O padrão é **lowercase**. Todas as *views* de um *controller* são armazenadas em uma pasta com o nome do *controller*. Cada view é nomeada de acordo com a *action*. Porém, é possível alterar estas configurações através do objeto **View**.
+O padrão é <b>lowercase</b>. Todas as *views* de um *controller* são armazenadas em uma pasta com o nome do *controller*. Cada view é nomeada de acordo com a *action*. Porém, é possível alterar estas configurações através do objeto <b>View</b>.
 
 ----
 ### Configurando a *View* {#configurando-a-view}
@@ -52,45 +52,44 @@ Estas são as opções disponíveis para configurar uma view:
 
 *O código resultante seria:*
 ```php
-    class ProdutosController extends \HXPHP\System\Controller
+class ProdutosController extends \HXPHP\System\Controller
+{
+    public function indexAction()
     {
-        public function indexAction()
-        {
-            $this->view->setPath('index')
-                   ->setFile('index')
-                   ->setHeader('header')
-                   ->setFooter('footer')
-                   ->setTemplate(true)
-                   ->setAssets('css', 'teste.css')
-                   ->setAssets('css', array(
-                        'teste2.css',
-                        'teste3.css'
-                    ))
-                   ->setAssets('js', array(
-                        'teste2.js',
-                        'teste3.js'
-                    ))
-                   ->setTitle('Oops! Nada encontrado!');
-        }
-	}
+        $this->view->setPath('index')
+               ->setFile('index')
+               ->setHeader('header')
+               ->setFooter('footer')
+               ->setTemplate(true)
+               ->setAssets('css', 'teste.css')
+               ->setAssets('css', array(
+                    'teste2.css',
+                    'teste3.css'
+                ))
+               ->setAssets('js', array(
+                    'teste2.js',
+                    'teste3.js'
+                ))
+               ->setTitle('Oops! Nada encontrado!');
+    }
+}
 ```
 ----
 ### Enviando dados para a *View* {#enviando-dados-para-a-view}
 
 ```php
-    class ProdutosController extends \HXPHP\System\Controller
+class ProdutosController extends \HXPHP\System\Controller
+{
+
+    public function indexAction()
     {
-
-      public function indexAction()
-      {
-       	$this->view->setVar('mensagem', 'Hello World')
-			   ->setVars(array(
-			   		'usuario' => 'Bruno Santos',
-			   		'facebook' => 'https://www.facebook.com/brunocsantos2012'
-			   	));
-      }
-
-	}
+      $this->view->setVar('mensagem', 'Hello World')
+                ->setVars([
+                        'usuario' => 'Bruno Santos',
+                        'facebook' => 'https://www.facebook.com/brunocsantos2012'
+                     )]);
+    }
+}
 ```
 
 Na *view* todos estes dados são extraídos e atribuídos em variáveis com o prefixo `view_`. No exemplo acima, as variáveis disponíveis na view seriam:
@@ -108,22 +107,22 @@ Para realizar este procedimento no HXPHP você pode criar *views parciais*. Por 
 
 Algumas observações:
 + O padrão para nomenclatura é que o nome do arquivo comece com "_". Ex: `_social-icons.phtml`, e;
-+ É possível passar dados para as views parciais. 
++ É possível passar dados para as views parciais.
 
 #### Exemplos
 
 + View parcial (app/views/partials/_message.phtml):
 ```php
-    <h4 class="alert alert-success">
-         echo $view_msg; ?>
-    </h4>
+<h4 class="alert alert-success">
+     echo $view_msg; ?>
+</h4>
 ```
 
 + Chamada da view partial em uma view (app/views/index/index.phtml):
 ```php
-    $this->partial('message', array(
-        'msg' => 'Uhull! Você instalou e configurou o HXPHP Framework com sucesso!'
-    ));
+$this->partial('message', [
+    'msg' => 'Uhull! Você instalou e configurou o HXPHP Framework com sucesso!'
+]);
 ```
 
 O método `partial()` suporta dois parâmetros:

--- a/06-views.md
+++ b/06-views.md
@@ -113,7 +113,7 @@ Algumas observações:
 + View parcial (app/views/partials/_message.phtml):
 ```php
 <h4 class="alert alert-success">
-     echo $view_msg; ?>
+    <?php echo $view_msg; ?>
 </h4>
 ```
 

--- a/07-load.md
+++ b/07-load.md
@@ -5,7 +5,7 @@ Esta seção aborda o carregamento de *Helpers*, Serviços, Módulos e outros co
 
 ----
 
-Para utilizar os *helpers* e demais componentes do framework, tanto na view como no controller, é necessário "injetar" o objeto no controller através do método `load()`. Este método contém apenas um argumento obrigatório que é a **localização do objeto**. É necessário informar a *namespace* correspondente e o nome do objeto. A *namespace*, em suma, é o nome da pasta *(considerando a pasta System como raiz)* em que o objeto se encontra.
+Para utilizar os *helpers* e demais componentes do framework, tanto na view como no controller, é necessário "injetar" o objeto no controller através do método `load()`. Este método contém apenas um argumento obrigatório que é a <b>localização do objeto</b>. É necessário informar a *namespace* correspondente e o nome do objeto. A *namespace*, em suma, é o nome da pasta *(considerando a pasta System como raiz)* em que o objeto se encontra.
 
 
 Os demais argumentos informados no método `load('Helpers\NomeDoHelper', $param1, $param2, $paramN)` serão utilizados como argumentos no método construtor do objeto que será carregado.
@@ -13,21 +13,20 @@ Os demais argumentos informados no método `load('Helpers\NomeDoHelper', $param1
 
 *O código resultante seria:*
 ```php
-  class ProdutosController extends \HXPHP\System\Controller
-  {
+class ProdutosController extends \HXPHP\System\Controller
+{
     public function indexAction()
     {
-      $this->load('Helpers\NomeDoHelper', 'param1', 'param2');
-      $this->load('Modules\NomeDoModulo', 'param1', 'param2');
-      $this->load('Storage\Session');
-      $this->load('Services\Email');
+        $this->load('Helpers\NomeDoHelper', 'param1', 'param2');
+        $this->load('Modules\NomeDoModulo', 'param1', 'param2');
+        $this->load('Storage\Session');
+        $this->load('Services\Email');
 
-      $this->nomedohelper->metodo();
-      echo $this->nomedomodulo->propriedade;
-      ...
+        $this->nomedohelper->metodo();
+        echo $this->nomedomodulo->propriedade;
+        ...
     }
-	}
+}
 ```
-
 
 Após injetar o objeto, no controller, cria-se um atributo com o seu nome no padrão *lowercase*.

--- a/08-helpers.md
+++ b/08-helpers.md
@@ -13,40 +13,38 @@ Os *Helpers* são componentes auxiliares. Em suma, são objetos que desempenham 
 
 ### Alert Helper {#alert-helper}
 
-O **Alert Helper** é responsável pela exibição de mensagens de aviso, erro, sucesso e afins.
+O <b>Alert Helper</b> é responsável pela exibição de mensagens de aviso, erro, sucesso e afins.
 
 Para utilizar este *helper* é necessário passar um *array* como parâmetro no construtor e este deve conter a seguinte estrutura:
 
 ```php
-  array(
+[
     'danger', // Classes Bootstrap disponíveis: danger, warning, info, success
     'Título da mensagem',
     'Conteúdo da mensagem' // Pode ser um array com várias mensagens
-  );
+];
 ```
-
 
 O código resultante seria:
 ```php
-  class ProdutosController extends \HXPHP\System\Controller
-  {
+class ProdutosController extends \HXPHP\System\Controller
+{
     public function indexAction()
     {
 
-      $alerta = [
-        'success',
-        'Uhuul! Produto cadastrado com sucesso!',
-        'O produto já está disponível para seus clientes.'
-      ];
+        $alerta = [
+          'success',
+          'Uhuul! Produto cadastrado com sucesso!',
+          'O produto já está disponível para seus clientes.'
+        ];
 
-      $this->load('Helpers\Alert', $alerta);
+        $this->load('Helpers\Alert', $alerta);
 
-      var_dump($this->alert->getAlert()); // ou
-      echo $this->alert;
+        var_dump($this->alert->getAlert()); // ou
+        echo $this->alert;
     }
-	}
+}
 ```
-
 
 O método `getAlert()`, responsável pela renderização do alerta, é inserido na *view* e geralmente é encontrado em cabeçalhos para evitar a repetição de códigos.
 
@@ -55,7 +53,7 @@ O método `getAlert()`, responsável pela renderização do alerta, é inserido 
 ----
 ### Menu Helper {#menu-helper}
 
-O **Menu Helper** tem a função de renderizar um menu customizado mediante o nível de acesso do usuário.
+O <b>Menu Helper</b> tem a função de renderizar um menu customizado mediante o nível de acesso do usuário.
 
 Diferentemente do *Alert Helper*, que trabalha com templates, este conta com um módulo específico de configuração. Portanto, antes de utilizá-lo, é necessário verificar se o módulo está registrado.
 
@@ -67,24 +65,24 @@ O módulo contém dois métodos:
 
 ##### Definindo a estrutura dos menus
 
-Exemplo de configuração para definir dois menus (o primeiro para usuários com nível de acesso igual a **administrator** e o segundo que é neutro):
+Exemplo de configuração para definir dois menus (o primeiro para usuários com nível de acesso igual a <b>administrator</b> e o segundo que é neutro):
 
 ```php
-  $configs->env->development->menu->setMenus(array(
-    'Home/home' => '%siteURL%',
-    'Projetos/briefcase' => '%baseURI%/projetos/listar/',
-    'Clientes/users' => array(
-      'Listar todos/users' => '%baseURI%',
-      'Tipos de clientes/users' => '%baseURI%/clientes/tipos'
-    ),
-    'Usuários/users' => '%baseURI%/usuarios/listar/'
-  ), 'administrator');
+    $configs->env->development->menu->setMenus([
+        'Home/home' => '%siteURL%',
+        'Projetos/briefcase' => '%baseURI%/projetos/listar/',
+        'Clientes/users' => [
+          'Listar todos/users' => '%baseURI%',
+          'Tipos de clientes/users' => '%baseURI%/clientes/tipos'
+        ],
+        'Usuários/users' => '%baseURI%/usuarios/listar/'
+    ], 'administrator');
 
 
-  $configs->env->development->menu->setMenus(array(
-    'Home/home' => '%siteURL%/home',
-    'Projetos/briefcase' => '%baseURI%/projetos/listar/'
-  ));
+    $configs->env->development->menu->setMenus([
+        'Home/home' => '%siteURL%/home',
+        'Projetos/briefcase' => '%baseURI%/projetos/listar/'
+    ]);
 ```
 
 Observações:
@@ -92,14 +90,14 @@ Observações:
 + O segundo argumento é opcional, isto é, também é possível definir um menu sem um nível de acesso para páginas públicas e afins;
 + O *array* com os menus é padronizado da seguinte forma:
 ```php
-  array(
+[
     'Menu Sem Dropdown/codigo-icone-font-awesome-sem-prefixo' => 'http://www.link-absoluto.com',
     'Usuários/users' => '%baseURI%/link-relativo',
-    'Menu Com Dropdown/home' => array(
+    'Menu Com Dropdown/home' => [
       'Submenu/briefcase' => '%baseURI%/link-relativo',
       'Submenu #2/users' => '%baseURI%/link-relativo'
-    )
-  )
+    ]
+]
 ```
 + É possível utilizar os coringas `%baseURI%` e `%siteURL%` que são substituídos pelo valor da configuração `baseURI` e pelo endereço do site, respectivamente;
 + A ferramenta [Font Awesome](http://fontawesome.io/) foi utilizada nos ícones que acompanham os títulos nos menus e submenus, e;
@@ -109,30 +107,30 @@ Observações:
 
 Exemplo com todas as possíveis configurações do menu:
 ```php
-    $configs->env->development->menu->setConfigs(array(
-      'container' => false, // Tag container (opcional). Ex: nav
-      'container_id' => '',
-      'container_class' => '',
-      'menu_id' => 'menu',
-      'menu_class' => 'menu',
-      'menu_item_class' => 'menu-item',
-      'menu_item_active_class' => 'active',
-      'menu_item_dropdown_class' => 'dropdown',
-      'link_before' => '<span>', // Conteúdo anterior ao título
-      'link_after' => '</span>', // Conteúdo posterior ao título
-      'link_class' => 'menu-link',
-      'link_active_class' => 'menu-active-link',
-      'link_dropdown_class' => 'dropdown-toggle',
-      'link_dropdown_attrs' => array(
-        'data-toggle' => 'dropdown' // Data Atributos para ativação do dropdown
-      ),
-      'dropdown_class' => 'dropdown-menu',
-      'dropdown_item_class' => 'dropdown-item',
-      'dropdown_item_active_class' => 'active'
-    ));
+$configs->env->development->menu->setConfigs([
+    'container' => false, // Tag container (opcional). Ex: nav
+    'container_id' => '',
+    'container_class' => '',
+    'menu_id' => 'menu',
+    'menu_class' => 'menu',
+    'menu_item_class' => 'menu-item',
+    'menu_item_active_class' => 'active',
+    'menu_item_dropdown_class' => 'dropdown',
+    'link_before' => '<span>', // Conteúdo anterior ao título
+    'link_after' => '</span>', // Conteúdo posterior ao título
+    'link_class' => 'menu-link',
+    'link_active_class' => 'menu-active-link',
+    'link_dropdown_class' => 'dropdown-toggle',
+    'link_dropdown_attrs' => [
+      'data-toggle' => 'dropdown' // Data Atributos para ativação do dropdown
+   ,
+    'dropdown_class' => 'dropdown-menu',
+    'dropdown_item_class' => 'dropdown-item',
+    'dropdown_item_active_class' => 'active'
+]);
 ```
 
-O exemplo acima está com todos os valores padrão, portanto, caso necessite customizar o seu menu, insira **apenas as configurações que deseja alterar** o valor padrão.
+O exemplo acima está com todos os valores padrão, portanto, caso necessite customizar o seu menu, insira <b>apenas as configurações que deseja alterar</b> o valor padrão.
 
 #### Carregando o Menu Helper no Controller
 
@@ -141,18 +139,18 @@ Este *helper* requer duas dependências no construtor: `Request` e `Configs`. E 
 
 O código resultante seria:
 ```php
-  class ProdutosController extends \HXPHP\System\Controller
-  {
+class ProdutosController extends \HXPHP\System\Controller
+{
     public function indexAction()
     {
-      $this->load(
-        'Helpers\Menu',
-        $this->request,
-        $this->configs,
-        $this->auth->getUserRole() //access_level
-      );
+        $this->load(
+            'Helpers\Menu',
+            $this->request,
+            $this->configs,
+            $this->auth->getUserRole() //access_level
+        );
     }
-  }
+}
 ```
 
 #### Renderizando o menu
@@ -161,5 +159,5 @@ Após configurar e carregar o *helper* na *action* desejada, será possível ren
 
 Exemplos:
 ```php
-  echo $this->menu->getMenu();
+echo $this->menu->getMenu();
 ```

--- a/08-helpers.md
+++ b/08-helpers.md
@@ -31,7 +31,6 @@ class ProdutosController extends \HXPHP\System\Controller
 {
     public function indexAction()
     {
-
         $alerta = [
           'success',
           'Uhuul! Produto cadastrado com sucesso!',
@@ -68,21 +67,21 @@ O módulo contém dois métodos:
 Exemplo de configuração para definir dois menus (o primeiro para usuários com nível de acesso igual a <b>administrator</b> e o segundo que é neutro):
 
 ```php
-    $configs->env->development->menu->setMenus([
-        'Home/home' => '%siteURL%',
-        'Projetos/briefcase' => '%baseURI%/projetos/listar/',
-        'Clientes/users' => [
-          'Listar todos/users' => '%baseURI%',
-          'Tipos de clientes/users' => '%baseURI%/clientes/tipos'
-        ],
-        'Usuários/users' => '%baseURI%/usuarios/listar/'
-    ], 'administrator');
+$configs->env->development->menu->setMenus([
+    'Home/home' => '%siteURL%',
+    'Projetos/briefcase' => '%baseURI%/projetos/listar/',
+    'Clientes/users' => [
+      'Listar todos/users' => '%baseURI%',
+      'Tipos de clientes/users' => '%baseURI%/clientes/tipos'
+    ],
+    'Usuários/users' => '%baseURI%/usuarios/listar/'
+], 'administrator');
 
 
-    $configs->env->development->menu->setMenus([
-        'Home/home' => '%siteURL%/home',
-        'Projetos/briefcase' => '%baseURI%/projetos/listar/'
-    ]);
+$configs->env->development->menu->setMenus([
+    'Home/home' => '%siteURL%/home',
+    'Projetos/briefcase' => '%baseURI%/projetos/listar/'
+]);
 ```
 
 Observações:

--- a/09-http.md
+++ b/09-http.md
@@ -8,87 +8,84 @@ Nesta seção você irá conhecer o processo de obtenção de dados via requisi�
 
 ### HTTP Request {#request}
 
-Para a obtenção de dados de requisições como **POST** e **GET** é necessário utilizar o objeto *Request*.
+Para a obtenção de dados de requisições como <b>POST</b> e <b>GET</b> é necessário utilizar o objeto *Request*.
 
 As vantagens são muitas e dentre as principais destaca-se a maior segurança, visto que os dados são tratados nativamente.
 
 O objeto *Request* contém os seguintes métodos:
 
-**Customização**
+<b>Customização</b>
 + `setCustomFilters()`;
 
-**Obtenção de dados**
+<b>Obtenção de dados</b>
 + `cookie()`;
 + `get()`;
 + `post()`;
 + `server()`;
 + `getMethod()`;
- 
-**Validação**
+
+<b>Validação</b>
 + `isValid()`;
 + `isPost()`;
 + `isGet()`;
 + `isPut()`, e;
 + `isHead()`.
 
-O método `setCustomFilters()` tem o objetivo de customizar os filtros de tratamento aplicados aos dados das requisições. Para tal, é necessário informar um ***array* associativo** com o índice igual ao nome do campo e o valor com a constante de filtro. Leia: [http://php.net/manual/en/filter.filters.sanitize.php](http://php.net/manual/en/filter.filters.sanitize.php). Por padrão, o filtro aplicado em todos os dados é o `FILTER_SANITIZE_STRING` que evita a injeção de códigos HTML.
+O método `setCustomFilters()` tem o objetivo de customizar os filtros de tratamento aplicados aos dados das requisições. Para tal, é necessário informar um <b>*array* associativo</b> com o índice igual ao nome do campo e o valor com a constante de filtro. Leia: [http://php.net/manual/en/filter.filters.sanitize.php](http://php.net/manual/en/filter.filters.sanitize.php). Por padrão, o filtro aplicado em todos os dados é o `FILTER_SANITIZE_STRING` que evita a injeção de códigos HTML.
 
 
 O código resultante seria:
-```php    
-    class ProdutosController extends \HXPHP\System\Controller
+```php
+class ProdutosController extends \HXPHP\System\Controller
+{
+    public function salvarAction()
     {
-        public function salvarAction()
-        {
-            $this->request->setCustomFilters(array(
-                'namedoinput' => FILTER_SANITIZE_NUMBER_FLOAT
-            ));
-        }
+        $this->request->setCustomFilters([
+            'namedoinput' => FILTER_SANITIZE_NUMBER_FLOAT
+        ]);
     }
+}
 ```
 
 ### Trabalhando com checkboxes, multiple selects e semelhantes
 
 Como o filtro padrão trata os dados para `STRING`, isto afeta a obtenção de dados de campos que enviam múltiplas informações. A solução é bem simples:
 
-```php    
-    class ProdutosController extends \HXPHP\System\Controller
+```php
+class ProdutosController extends \HXPHP\System\Controller
+{
+    public function salvarAction()
     {
-        public function salvarAction()
-        {
-            $this->request->setCustomFilters(array(
-                'id' => array(
-                    'filter' => FILTER_SANITIZE_NUMBER_INT,
-                    'flags' => FILTER_FORCE_ARRAY
-                )
-            ));
-
-        }
+        $this->request->setCustomFilters([
+            'id' => [
+                'filter' => FILTER_SANITIZE_NUMBER_INT,
+                'flags' => FILTER_FORCE_ARRAY
+            ]
+        ]);
     }
+}
 ```
 
 No exemplo acima, utilizamos a *flag* `FILTER_FORCE_ARRAY` que irá sempre retornar um array no campo definido e em conjunto com um filtro para tratar os valores para números inteiros.
 
 Já os métodos `get()` e `post()` retornam os dados filtrados, sendo que é possível retornar todo o conteúdo ou apenas um dado específico.
 
-
 O código resultante seria:
 ```php
-    class ProdutosController extends \HXPHP\System\Controller
+class ProdutosController extends \HXPHP\System\Controller
+{
+    public function salvarAction()
     {
-        public function salvarAction()
-        {
-            $this->request->setCustomFilters(array(
-                'nomedocampo' => FILTER_SANITIZE_NUMBER_FLOAT
-            ));
+        $this->request->setCustomFilters([
+            'nomedocampo' => FILTER_SANITIZE_NUMBER_FLOAT
+        ]);
 
-            print_r($this->request->post()); //Array com todos os dados enviados via POST
-            echo $this->request->post('nomedocampo'); //Apenas o conteúdo do campo valor
-            
-            echo $this->request->server('SERVER_NAME');
-        }
+        print_r($this->request->post()); //Array com todos os dados enviados via POST
+        echo $this->request->post('nomedocampo'); //Apenas o conteúdo do campo valor
+
+        echo $this->request->server('SERVER_NAME');
     }
+}
 ```
-
 
 E, por fim, têm-se os métodos: `getMethod()`, `isPost()`, `isGet()`, `isPut()` e `isHead()` que tem como função determinar qual é o método de requisição.

--- a/10-storage.md
+++ b/10-storage.md
@@ -7,18 +7,18 @@
 Para trabalhar com sessões é necessário utilizar os recursos de *Storage*. Para tal, utiliza-se o objeto *Session* que contém os seguintes métodos:
 
 ```php
-    class ProdutosController
+class ProdutosController
+{
+    public function listarAction()
     {
-        public function listarAction()
-        {
-            $this->load('Storage\Session');
+        $this->load('Storage\Session');
 
-            $this->session->set('name', 'value'); //Cria uma sessão
-            echo $this->session->get('name'); //Seleciona uma sessão
-            $this->session->clear('name'); //Exclui uma sessão
-            print_r($this->session->exists('name')); //Verifica a existência de uma sessão
-        }
+        $this->session->set('name', 'value'); //Cria uma sessão
+        echo $this->session->get('name'); //Seleciona uma sessão
+        $this->session->clear('name'); //Exclui uma sessão
+        print_r($this->session->exists('name')); //Verifica a existência de uma sessão
     }
+}
 ```
 
 ### Cookies
@@ -31,16 +31,16 @@ Para trabalhar com *cookies* utiliza-se o objeto *Cookie* que contém os seguint
 + `clear()`.
 
 ```php
-    class ProdutosController
+class ProdutosController
+{
+    public function listarAction()
     {
-        public function listarAction()
-        {
-            $this->load('Storage\Cookie');
+        $this->load('Storage\Cookie');
 
-            $this->cookie->set('name', 'value', '31556926'); //Cria um cookie ($name, $value, $time)
-            echo $this->cookie->get('name'); //Seleciona um cookie
-            $this->cookie->clear('name'); // Exclui um cookie
-            print_r($this->cookie->exists('name')); //Verifica a existência do cookie
-        }
+        $this->cookie->set('name', 'value', '31556926'); //Cria um cookie ($name, $value, $time)
+        echo $this->cookie->get('name'); //Seleciona um cookie
+        $this->cookie->clear('name'); // Exclui um cookie
+        print_r($this->cookie->exists('name')); //Verifica a existência do cookie
     }
+}
 ```

--- a/11-modules.md
+++ b/11-modules.md
@@ -10,16 +10,16 @@ Módulos são basicamente plugins, ou seja, são bibliotecas de códigos que tem
 ----
 ### *Message Module* {#message-module}
 
-O único módulo nativo do framework é o **Message Module**. Ele é responsável por gerenciar todas as mensagens de erro, aviso, sucesso e etc.
+O único módulo nativo do framework é o <b>Message Module</b>. Ele é responsável por gerenciar todas as mensagens de erro, aviso, sucesso e etc.
 
 Para utilizar este módulo é necessário:
 
 + Criar um template de mensagens no formato JSON, e;
-+ Salvar na pasta `templates/Modules/Messages/`. 
++ Salvar na pasta `templates/Modules/Messages/`.
 
 Veja o exemplo do template `auth.json`:
 ```json
-  {
+{
     "description" : "Template de mensagens para o serviço de autenticação",
     "messages" : {
         "usuario-bloqueado" : {
@@ -54,8 +54,7 @@ Veja o exemplo do template `auth.json`:
             "message" : "Não foi possível realizar a autenticação, confira seus dados!"
         }
     }
-  }
-
+}
 ```
 
 Perceba que existem três estruturas principais:
@@ -64,36 +63,36 @@ Perceba que existem três estruturas principais:
 + Messages, e;
 + Alerts.
 
-A estrutura **description** deve conter a descrição do template. 
+A estrutura <b>description</b> deve conter a descrição do template.
 
-Já a estrutura **messages** deve acomodar mensagens que serão enviadas por e-mail. 
+Já a estrutura <b>messages</b> deve acomodar mensagens que serão enviadas por e-mail.
 
-E, por fim, a estrutura **alerts** que deve acomodar as mensagens que serão renderizadas pelo [Alert Helper](#alert-helper).
+E, por fim, a estrutura <b>alerts</b> que deve acomodar as mensagens que serão renderizadas pelo [Alert Helper](#alert-helper).
 
-As estruturas **messages** e **alerts** contém seções pré-definidas:
+As estruturas <b>messages</b> e <b>alerts</b> contém seções pré-definidas:
 
-+ **subject** e **message** para a a estrutura **messages**, e;
-+ **style**, **title** e **message** para a estrutura **alerts**.
++ <b>subject</b> e <b>message</b> para a a estrutura <b>messages</b>, e;
++ <b>style</b>, <b>title</b> e <b>message</b> para a estrutura <b>alerts</b>.
 
 Estas seções devem ser acomodadas dentro de uma estrura intermediária que é nomeada com um código referente ao seu conteúdo.
 
-Após criar e preencher os templates com seus respectivos conteúdos é possível resgatar estes valores de forma prática através do **Messages Module**.
+Após criar e preencher os templates com seus respectivos conteúdos é possível resgatar estes valores de forma prática através do <b>Messages Module</b>.
 
 O primeiro passo é declarar para o método construtor do módulo qual é o nome do template que será utilizado.
 
-Obs: **Lembre-se de não informar a extensão .json**.
+Obs: <b>Lembre-se de não informar a extensão .json</b>.
 
 O código resultante seria:
 ```php
-  $messages = new Messages('auth');
-  //ou
-  $this->load('Modules\Messages', 'auth');
+$messages = new Messages('auth');
+//ou
+$this->load('Modules\Messages', 'auth');
 ```
 
 Para retornar o conteúdo de uma mensagem|alerta é necessário utilizar o seguinte caminho:
 
 ```php
-  $this->messages->alerts->getByCode('conta-em-uso');
+$this->messages->alerts->getByCode('conta-em-uso');
 ```
 
 Executando o código acima tem-se como retorno um *array* no formato necessário para ser interpretado pelo [Alert Helper](#alert-helper).
@@ -101,21 +100,21 @@ Executando o código acima tem-se como retorno um *array* no formato necessário
 Perceba que `{alerts}` é uma das opções disponíveis, isto é, trata-se da estrutura que você deseja utilizar. No template anteriormente apresentado, pode-se observar duas estruturas: *messages* e *alerts*.
 
 ```php
-  $this->messages->messages->getByCode('usuario-bloqueado');
+$this->messages->messages->getByCode('usuario-bloqueado');
 ```
 
 Caso queira definir uma estrutura padrão e utilizar diretamente o método `getByCode($codigo)` configure o método `setBlock($estrutura);`.
 
 ```php
-  $this->messages->setBlock('messages');
-  $this->messages->getByCode('usuario-bloqueado');
+$this->messages->setBlock('messages');
+$this->messages->getByCode('usuario-bloqueado');
 ```
 
 Também é possível preencher valores coringas presentes na mensagem do template (%s), para tal, é necessário informar estes parâmetros em um *array* seguindo o padrão abaixo:
 
 Template para exemplo:
 ```json
-  {
+{
     "description" : "Template de mensagens para exemplo",
     "alerts" : {
         "codigo" : {
@@ -124,21 +123,20 @@ Template para exemplo:
             "message" : "Olá %s %s, como vai?"
         }
     }
-  }
+}
 ```
 O código resultante seria:
 ```php
-  $this->load('Modules\Messages', 'meutemplate');
-  $this->messages->setBlock('alerts');
+$this->load('Modules\Messages', 'meutemplate');
+$this->messages->setBlock('alerts');
 
-  $substituir_coringas = array(
+$substituir_coringas = [
     'title' => 'Hello World',
-    'message' => array(
+    'message' => [
       'Bruno',
       'Santos'
-    )
-  );
+    ]
+];
 
-
-  $this->messages->getByCode('codigo', $substituir_coringas);
+$this->messages->getByCode('codigo', $substituir_coringas);
 ```

--- a/12-services.md
+++ b/12-services.md
@@ -32,15 +32,15 @@ Para facilitar a configuração deste serviço existe um módulo de configuraç�
 
 Configuração na prática:
 ```php
-	$configs->env->development->auth->setURLs(
-		'/hxphp/home/', 
-		'/hxphp/login/'
-	);
-	$configs->env->development->auth->setURLs(
-		'/hxphp/admin/home/', 
-		'/hxphp/admin/login/', 
-		'admin'
-	);
+$configs->env->development->auth->setURLs(
+    '/hxphp/home/',
+    '/hxphp/login/'
+);
+$configs->env->development->auth->setURLs(
+    '/hxphp/admin/home/',
+    '/hxphp/admin/login/',
+    'admin'
+);
 ```
 
 O módulo de configuração suporta 3 parâmetros:
@@ -51,39 +51,37 @@ O módulo de configuração suporta 3 parâmetros:
 
 Após definir todas as configurações, carregue o serviço no controller:
 ```php
-    class LoginController extends \HXPHP\System\Controller
+class LoginController extends \HXPHP\System\Controller
+{
+    public function __construct($configs)
     {
-    	public function __construct($configs)
-    	{
-            parent::__construct($configs);
+        parent::__construct($configs);
 
-            $this->load(
-				'Services\Auth',
-				$this->configs->auth->after_login,
-				$this->configs->auth->after_logout,
-				true,
-				$this->request->subfolder
-			);
-		
-			// Páginas públicas
-			$this->auth->redirectCheck(true);
+        $this->load('Services\Auth',
+            $this->configs->auth->after_login,
+            $this->configs->auth->after_logout,
+            true,
+            $this->request->subfolder
+        );
 
-			// Páginas privadas
-			//$this->auth->redirectCheck();
-    	}
+        // Páginas públicas
+        $this->auth->redirectCheck(true);
 
-		public function logarAction()
-		{
-			$this->auth->login(1, 'brunosantos', 'user');
-		}
-
-		public function sairAction()
-		{
-			$this->auth->logout();
-		}
+        // Páginas privadas
+        //$this->auth->redirectCheck();
     }
-```
 
+    public function logarAction()
+    {
+        $this->auth->login(1, 'brunosantos', 'user');
+    }
+
+    public function sairAction()
+    {
+        $this->auth->logout();
+    }
+}
+```
 
 Este serviço geralmente trabalha em conjunto com o *model* de usuários e autentica somente após todas as validações obterem sucesso.
 
@@ -99,10 +97,10 @@ O primeiro tem a função de definir o nome e e-mail do remetente e o segundo de
 
 Exemplo de configuração:
 ```php
-	$configs->env->development->mail->setFrom([
-		'from' => 'Remetente',
-		'from_mail' => 'email@remetente.com.br'
-	]);
+$configs->env->development->mail->setFrom([
+    'from' => 'Remetente',
+    'from_mail' => 'email@remetente.com.br'
+]);
 ```
 
 O serviço contém dois métodos:
@@ -110,20 +108,20 @@ O serviço contém dois métodos:
 + `setFrom(array $from)`, e;
 + `send(...)`.
 
-O método `setFrom()` do **módulo de configuração** tem os objetivos de definir as credenciais globais e tornar estes valores disponíveis no controller. Já o método do serviço é que definirá realmente qual será a credencial utilizada, isto é, tanto é possível utilizar as credenciais do módulo com o método `getFrom()` como também definir um valor diferente.
+O método `setFrom()` do <b>módulo de configuração</b> tem os objetivos de definir as credenciais globais e tornar estes valores disponíveis no controller. Já o método do serviço é que definirá realmente qual será a credencial utilizada, isto é, tanto é possível utilizar as credenciais do módulo com o método `getFrom()` como também definir um valor diferente.
 
 Exemplo de uso:
 ```php
-	$this->load('Services\Email');
+$this->load('Services\Email');
 
-	$this->email->setFrom([
-		'from' => 'Remetente',
-		'from_mail' => 'email@remetente.com.br'
-	]);
+$this->email->setFrom([
+    'from' => 'Remetente',
+    'from_mail' => 'email@remetente.com.br'
+]);
 
-	// ou
-	
-	$this->email->setFrom($this->configs->mail->getFrom());
+// ou
+
+$this->email->setFrom($this->configs->mail->getFrom());
 ```
 
 
@@ -140,30 +138,28 @@ Após executar o método `send()` ele retornará um booleano com o status do pro
 
 Serviço na prática:
 ```php
-    class ProdutosController extends \HXPHP\System\Controller
+class ProdutosController extends \HXPHP\System\Controller
+{
+    public function comprarAction()
     {
+        $this->load('Services\Email');
+        $this->email->setFrom($this->configs->mail->getFrom());
 
-        public function comprarAction()
-        {
-            $this->load('Services\Email');
-            $this->email->setFrom($this->configs->mail->getFrom());
+        $compraComSucesso = $this->email->send(
+            'fulano@email.com.br',
+            'Compra realizada com sucesso!',
+            'Mensagem',
+            [],
+            false
+        );
 
-            $compraComSucesso = $this->email->send(
-            	'fulano@email.com.br',
-            	'Compra realizada com sucesso!',
-            	'Mensagem',
-            	[],
-            	false
-            );
-
-            $outroEmail = $this->email->send(
-            	'fulano@email.com.br',
-            	'Outro e-mail',
-            	'Mensagem'
-            );
-        }
-
+        $outroEmail = $this->email->send(
+            'fulano@email.com.br',
+            'Outro e-mail',
+            'Mensagem'
+        );
     }
+}
 ```
 
 ----
@@ -176,23 +172,22 @@ Este link deve ser absoluto e ter **obrigatoriamente** uma `/` no final, pois o 
 O token é uma propriedade pública e deve ser utilizado para validar a autenticidade da redefinição durante todo o processo.
 
 Serviço na prática:
-```php        
-    class EsqueciASenhaController extends \HXPHP\System\Controller
+```php
+class EsqueciASenhaController extends \HXPHP\System\Controller
+{
+    public function enviarAction()
     {
-        public function enviarAction()
-        {
-            $this->load(
-                'Services\PasswordRecovery',
-                $this->configs->site->url . 
-                $this->configs->baseURI . 
-                'recuperar/redefinir/'
-            );
+        $this->load(
+            'Services\PasswordRecovery',
+            $this->configs->site->url .
+            $this->configs->baseURI .
+            'recuperar/redefinir/'
+        );
 
-            echo $this->passwordrecovery->link;
-            echo $this->passwordrecovery->token;
-        }
-
+        echo $this->passwordrecovery->link;
+        echo $this->passwordrecovery->token;
     }
+}
 ```
 
 
@@ -201,7 +196,7 @@ O token gerado deverá ser armazenado no banco de dados para validação futura 
 
 Obtenção do TOKEN:
 ```php
-    $token = $this->passwordrecovery->token;
+$token = $this->passwordrecovery->token;
 ```
 
 ----
@@ -212,15 +207,15 @@ O serviço de sessão tem a única finalidade de iniciar a sessão do PHP de for
 
 Serviço na prática:
 ```php
-	\HXPHP\System\Services\StartSession\StartSession::sec_session_start();
+\HXPHP\System\Services\StartSession\StartSession::sec_session_start();
 ```
 
 ----
 ### Serviço Simple cURL {#servico-simple-curl}
 
-É muito comum a necessidade de obter e enviar dados para URLs externas através de código. Existem diferentes formas de realizar esta tarefa e uma delas é com o uso da biblioteca cURL. 
+É muito comum a necessidade de obter e enviar dados para URLs externas através de código. Existem diferentes formas de realizar esta tarefa e uma delas é com o uso da biblioteca cURL.
 
-O framework contém um serviço que executa uma das aplicações mais comuns desta biblioteca. 
+O framework contém um serviço que executa uma das aplicações mais comuns desta biblioteca.
 
 O serviço *Simple cURL* contém um único método estático (`connect()`) que suporta 3 parâmetros:
 
@@ -238,14 +233,14 @@ Algumas observações:
 
 Serviço na prática:
 ```php
-	$retorno = \HXPHP\System\Services\SimplecURL\SimplecURL::connect(
-		'http://www.hxphp.com.br/produtos/novo',
-		array(
-			'name' => 'Curso Dominando o HXPHP Framework',
-			'description' => 'Lorem Ipsum'
-		),
-		array(
-			'token' => '1RSG6K2MV0PS2LVM01PD'
-		)
-	);
+$retorno = \HXPHP\System\Services\SimplecURL\SimplecURL::connect(
+    'http://www.hxphp.com.br/produtos/novo',
+    [
+        'name' => 'Curso Dominando o HXPHP Framework',
+        'description' => 'Lorem Ipsum'
+    ],
+    [
+        'token' => '1RSG6K2MV0PS2LVM01PD'
+    ]
+);
 ```

--- a/13-tools.md
+++ b/13-tools.md
@@ -7,7 +7,7 @@ Nesta seção você irá conhecer o objeto auxiliar *Tools*.
 
 O objeto *Tools* é uma ferramenta de apoio geral, ou seja, trata-se de um objeto que contém métodos comuns com funções de filtro, tratamento, criptografia e afins.
 
-Por padrão, este objeto contém os seguintes métodos **estáticos**:
+Por padrão, este objeto contém os seguintes métodos <b>estáticos</b>:
 
 + `dd($data, $dump = false)` - Exibe os dados;
 + `hashHX($password, $salt = null)` - Criptografa a senha do usuário no padrão HXPHP;
@@ -18,19 +18,19 @@ Por padrão, este objeto contém os seguintes métodos **estáticos**:
 
 #### Criptografia para senhas
 
-Um dos recursos do HXPHP mais utilizados para sistemas de cadastro e login é a criptografia de senhas. 
+Um dos recursos do HXPHP mais utilizados para sistemas de cadastro e login é a criptografia de senhas.
 
 + Gerando o `hash` e o `salt`:
 ```php
-	\HXPHP\System\Tools::hashHX('senhabruta');
+\HXPHP\System\Tools::hashHX('senhabruta');
 
-    /**
-     * Retorno:
-     * array (
-     *  'salt' => '...',
-     *  'password' => '...'
-     * );
-     */
+/**
+    * Retorno:
+    * [
+    *   'salt' => '...',
+    *   'password' => '...'
+    * ];
+*/
 ```
 
 O `salt` é um valor randômico que é concatenado com a senha bruta informada para gerar o `hash`.
@@ -39,10 +39,10 @@ O `salt` é um valor randômico que é concatenado com a senha bruta informada p
 
 + Gerando o `hash` para validação com a senha bruta e um `salt` já definido:
 ```php
-    $senhaCriptografada = \HXPHP\System\Tools::hashHX('senhabruta', $user->salt);
+$senhaCriptografada = \HXPHP\System\Tools::hashHX('senhabruta', $user->salt);
 
-    if ($user->password === $senhaCriptografada['password'])
-        return 'Usuário autenticado';
+if ($user->password === $senhaCriptografada['password'])
+    return 'Usuário autenticado';
 ```
 
 Como o `salt` é um valor aleatório, se o mesmo não for informado não será possível obter um `hash` idêntico para comparação mesmo que a senha informada pelo usuário esteja correta. Portanto, é necessário informar o `salt` que foi gerado para o `hash` armazenado no banco de dados, isto é, ambos os valores devem ser armazenados utilizados conforme o exemplo acima.

--- a/14-goodbye.md
+++ b/14-goodbye.md
@@ -3,7 +3,7 @@
 
 Olá, como vai você? Desde já, quero te parabenizar por concluir a leitura dessa extensa documentação. Conheço muito bem a dificuldade de se estudar frameworks com documentações confusas e muito diretas e, por isso, busquei trazer mais do que meramente um manual, mas, sim, algo como uma apostila ou um e-book. Lembre-se que esta documentação reúne diversos conceitos e boas práticas que podem aprimorar, ainda mais, os seus códigos.
 
-O HXPHP não foi desenvolvido para ser o **framework perfeito**, nem o **framework do código lindo** e sim, na verdade, ser o **framework de iniciação** dos programadores PHP. Trata-se de uma ferramenta simples que tem o objetivo nobre de apresentar o universo dos frameworks com um primeiro contato fácil e produtivo. E, para isso, em poucas horas o programador já é capaz de criar diversas soluções; fator este mais do que estimulante.
+O HXPHP não foi desenvolvido para ser o <b>framework perfeito</b>, nem o <b>framework do código lindo</b> e sim, na verdade, ser o <b>framework de iniciação</b> dos programadores PHP. Trata-se de uma ferramenta simples que tem o objetivo nobre de apresentar o universo dos frameworks com um primeiro contato fácil e produtivo. E, para isso, em poucas horas o programador já é capaz de criar diversas soluções; fator este mais do que estimulante.
 
 Lembre-se também que antes de estudar um framework é mais do que recomendado, imprescindível, o domínio da linguagem PHP em si. Afinal, independente do framework, você deve ser um programador PHP.
 


### PR DESCRIPTION
Olá @brunosantoshx, como vai?

Não é só o repositório do framework HXHP que merece atenção, muito pelo contrário, a documentação é importantíssima. Percebi que o GitHub não realizava a formatação de palavras em negrito quando adicionávamos as `**tags de negrito** `, portanto realizei algumas modificações com HTML puro e <b>surtiu efeito</b>.

Também intendei os códigos PHP de exemplo, e substitui as notações de `array()` para `[]`.

Espero que goste das modificações.

Abraços